### PR TITLE
updated for auto setup environment variables in the /etc/environment

### DIFF
--- a/fcitx5.sh
+++ b/fcitx5.sh
@@ -46,11 +46,11 @@ printf " \n \n"
 ###------ Startup ------###
 
 # finding the presend directory and log file
-present_dir="$(dirname "$(realpath "$0")")"
-cache_dir="$present_dir/.cache"
+dir="$(dirname "$(realpath "$0")")"
+cache_dir="$dir/.cache"
 
 # log directory
-log="$present_dir/Install.log"
+log="$dir/Install.log"
 if [[ ! -f "$log" ]]; then
     touch "$log"
 fi
@@ -75,6 +75,8 @@ else
     printf "${error}\n! No supported package manager found!\n"
     exit 1
 fi
+
+clear
 
 
 # Print message about installing necessary packages
@@ -185,6 +187,14 @@ sudo make install 2>&1 | tee -a "$log" || {
     printf "${error}\n! Installation failed\n"
     exit 1
 }
+
+sleep 1 && clear
+
+# setting things in the /etc/environment
+printf "${action}\n==> Setting things for fcitx5"
+echo "GTK_IM_MODULE=fcitx
+QT_IM_MODULE=fcitx
+XMODIFIERS=@im=fcitx" | sudo tee /etc/environment &> /dev/null
 
 printf "${done}\n==> Installation completed successfully!\n"
 

--- a/fcitx5.sh
+++ b/fcitx5.sh
@@ -196,6 +196,16 @@ echo "GTK_IM_MODULE=fcitx
 QT_IM_MODULE=fcitx
 XMODIFIERS=@im=fcitx" | sudo tee /etc/environment &> /dev/null
 
+# installing bangla fonts
+printf "${action}\n==> Now installing some Bangla Fonts\n"
+
+git clone --depth=1 https://github.com/shell-ninja/Bangla-Fonts.git "$dir/.cache/Bangla-Fonts"
+
+if [[ -d "$dir/.cache/Bangla-Fonts" ]]; then
+    cp -r "$dir/.cache/Bangla-Fonts/Bangla-Fonts" ~/.local/share/fonts/
+    sudo fc-cache -fv
+fi
+
 printf "${done}\n==> Installation completed successfully!\n"
 
 exit 0

--- a/ibus.sh
+++ b/ibus.sh
@@ -46,14 +46,16 @@ printf " \n \n"
 ###------ Startup ------###
 
 # finding the presend directory and log file
-present_dir="$(dirname "$(realpath "$0")")"
-cache_dir="$present_dir/.cache"
+dir="$(dirname "$(realpath "$0")")"
+cache_dir="$dir/.cache"
 
 # log directory
-log="$present_dir/Install.log"
+log="$dir/Install.log"
 if [[ ! -f "$log" ]]; then
     touch "$log"
 fi
+
+clear
 
 
 # Detect package manager
@@ -193,6 +195,14 @@ sudo make install 2>&1 | tee -a "$log" || {
     printf "${error}\n! Installation failed\n"
     exit 1
 }
+
+sleep 1 && clear
+
+# setting things in the /etc/environment
+printf "${action}\n==> Setting things for ibus"
+echo "GTK_IM_MODULE=ibus
+QT_IM_MODULE=ibus
+XMODIFIERS=@im=ibus" | sudo tee /etc/environment &> /dev/null
 
 printf "${done}\n==> Installation completed successfully!\n"
 

--- a/ibus.sh
+++ b/ibus.sh
@@ -204,6 +204,17 @@ echo "GTK_IM_MODULE=ibus
 QT_IM_MODULE=ibus
 XMODIFIERS=@im=ibus" | sudo tee /etc/environment &> /dev/null
 
+# installing bangla fonts
+printf "${action}\n==> Now installing some Bangla Fonts\n"
+
+git clone --depth=1 https://github.com/shell-ninja/Bangla-Fonts.git "$dir/.cache/Bangla-Fonts"
+
+if [[ -d "$dir/.cache/Bangla-Fonts" ]]; then
+    cp -r "$dir/.cache/Bangla-Fonts/Bangla-Fonts" ~/.local/share/fonts/
+    sudo fc-cache -fv
+fi
+
+
 printf "${done}\n==> Installation completed successfully!\n"
 
 exit 0


### PR DESCRIPTION
#### I have added a section to automatically append environment variables in the **/etc/environment** file.
Here is a preview:
- fcitx5:
```bash
echo "GTK_IM_MODULE=fcitx
QT_IM_MODULE=fcitx
XMODIFIERS=@im=fcitx" | sudo tee /etc/environment &> /dev/null
```

- ibus:
```bash
echo "GTK_IM_MODULE=ibus
QT_IM_MODULE=ibus
XMODIFIERS=@im=ibus" | sudo tee /etc/environment &> /dev/null
```
